### PR TITLE
Update Installing-on-macOS

### DIFF
--- a/docs/Other/Installing-on-macOS.md
+++ b/docs/Other/Installing-on-macOS.md
@@ -4,8 +4,10 @@ There is currently two ways to install Unciv on macOS. It is recommended that yo
 
 ## Installing using JAR
 
-1. If you don't already have Java 8 installed on your mac make sure you download it from the [official website](https://java.com/en/download/). Once you have downloaded the file open it and follow the instructions on screen.
-2. Now that you have Java 8 installed it's time to download the latest Unciv JAR. This can be done from the [releases](https://github.com/yairm210/Unciv/releases) screen here on Github. Download the file called Unciv.jar.
+1. If you don't already have Java 8 or OpenJDK (versions 11 and 18 do work) installed on your mac, either 
+  * Download it from the [official website](https://java.com/en/download/). Once you have downloaded the file, open it and follow the instructions on screen.
+  * If you use [Homebrew](https://brew.sh/), just run `brew install java`
+2. Now that you have Java installed it's time to download the latest Unciv JAR. This can be done from the [releases](https://github.com/yairm210/Unciv/releases) screen here on Github. Download the file called *Unciv.jar*.
 3. To run the game, you'll need to create to run `java -jar Unciv.jar` from a Terminal.
 4. Alternatively, you could create a 'Unciv.sh' file containing that line, and then run the new file, to allow you to create shortcuts etc.
 


### PR DESCRIPTION
As a complement to the simplification of #7828, I propose to ease a bit the installation instructions for mac, proposing to use Homebrew as it is a de-facto standard and as the installation of the official Java 8 may seem scary to some users.

I left both choices to not induce a breaking change, but I'm open to keep only one method. 
@yairm210 and @nacro711072 FYI